### PR TITLE
Use micromamba for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,8 +12,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Conda environment from environment.yml
       uses: mamba-org/provision-with-micromamba@main
-      with:
-        cache-env: true
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,8 +11,6 @@ jobs:
     - name: Install Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
-        environment-file: environment.yml
-        environment-name: mypy
         cache-downloads: true
         cache-env: true
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,5 +17,6 @@ jobs:
         cache-env: true
 
     - name: Test with pytest
+      shell: bash -l {0}
       run: |
-        mypy -m pytest
+        python -m pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install Conda environment from environment.yml
+    - name: Install Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
+      with:
+        environment-file: environment.yml
+        channels: pytorch,nvidia
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,9 +12,10 @@ jobs:
       uses: mamba-org/provision-with-micromamba@main
       with:
         environment-file: environment.yml
+        environment-name: mypy
         cache-downloads: true
         cache-env: true
 
     - name: Test with pytest
       run: |
-        python -m pytest
+        mypy -m pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ jobs:
     - name: Install Conda environment from environment.yml
       uses: mamba-org/provision-with-micromamba@main
       with:
+        environment-file: environment.yml
         cache-env: true
 
     - name: Test with pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,13 +3,11 @@ name: CI
 on: [push]
 
 jobs:
-  build-linux:
+  test:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
-
     steps:
     - uses: actions/checkout@v3
+
     - name: Install Conda environment from environment.yml
       uses: mamba-org/provision-with-micromamba@main
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,25 +10,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v3
+    - name: Install Conda environment from environment.yml
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        python-version: 3.7
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda env update --file environment.yml --name base
-    - name: Lint with flake8
-      run: |
-        conda install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        cache-env: true
+
     - name: Test with pytest
       run: |
-        conda install pytest
-        pytest
+        mamba install pytest
+        python -m pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,8 +12,9 @@ jobs:
       uses: mamba-org/provision-with-micromamba@main
       with:
         environment-file: environment.yml
+        cache-downloads: true
+        cache-env: true
 
     - name: Test with pytest
       run: |
-        mamba install pytest
         python -m pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,6 @@ jobs:
     - name: Install Conda environment from environment.yml
       uses: mamba-org/provision-with-micromamba@main
       with:
-        environment-file: environment.yml
         cache-env: true
 
     - name: Test with pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,6 @@ jobs:
       uses: mamba-org/provision-with-micromamba@main
       with:
         environment-file: environment.yml
-        channels: pytorch,nvidia
 
     - name: Test with pytest
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: DiffDRR
 channels:
-  - defaults
   - pytorch
   - nvidia
   - conda-forge


### PR DESCRIPTION
Closes #60 

Switches out building environments with conda for micromamba. Build times are so much faster with micromamba. Also, micromamba enables caching of downloads and environments, adding even more speed gains to build times!