### PR TITLE
Use conda for testing and docs deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,45 @@ on:
   push:
     branches: [ "main", "master" ]
   workflow_dispatch:
+
 jobs:
-  deploy:
+  test_and_deploy:
     runs-on: ubuntu-latest
-    steps: [uses: fastai/workflows/quarto-ghp@master]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Activate conda env with environment.yml
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: false
+          auto-activate-base: false
+          activate-environment: gtbook
+          python-version: 3.9
+          environment-file: environment.yml
+
+      - name: Install nbdev
+        shell: bash -l {0}
+        run: |
+          pip install -U nbdev
+
+      - name: Doing editable install
+        shell: bash -l {0}
+        run: |
+          test -f setup.py && pip install -e ".[dev]"
+
+      - name: Run nbdev_docs
+        shell: bash -l {0}
+        run: |
+          nbdev_docs
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ github.token }}
+          force_orphan: true
+          publish_dir: ./_docs
+          # The following lines assign commit authorship to the official GH-Actions bot for deploys to `gh-pages` branch.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,13 +17,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Activate conda env with environment.yml
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/setup-micromamba@v1
         with:
-          auto-update-conda: false
-          auto-activate-base: false
-          activate-environment: gtbook
-          python-version: 3.9
+          micromamba-version: '1.3.1-0'
           environment-file: environment.yml
+          init-shell: >-
+            bash
+            powershell
+          cache-environment: true
+          post-cleanup: 'all'
 
       - name: Install nbdev
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,20 +2,22 @@ name: CI
 on:  [workflow_dispatch, pull_request, push]
 
 jobs:
-  test_and_deploy:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Activate conda env with environment.yml
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/setup-micromamba@v1
         with:
-          auto-update-conda: false
-          auto-activate-base: false
-          activate-environment: diffdrr
-          python-version: 3.9
+          micromamba-version: '1.3.1-0'
           environment-file: environment.yml
+          init-shell: >-
+            bash
+            powershell
+          cache-environment: true
+          post-cleanup: 'all'
 
       - name: Install nbdev
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,64 @@ name: CI
 on:  [workflow_dispatch, pull_request, push]
 
 jobs:
-  test:
+  test_and_deploy:
     runs-on: ubuntu-latest
-    steps: [uses: fastai/workflows/nbdev-ci@master]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Activate conda env with environment.yml
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: false
+          auto-activate-base: false
+          activate-environment: gtbook
+          python-version: 3.9
+          environment-file: environment.yml
+
+      - name: Install nbdev
+        shell: bash -l {0}
+        run: |
+          pip install -U nbdev
+
+      - name: Doing editable install
+        shell: bash -l {0}
+        run: |
+          test -f setup.py && pip install -e ".[dev]"
+
+      - name: Check we are starting with clean git checkout
+        shell: bash -l {0}
+        run: |
+          if [[ `git status --porcelain -uno` ]]; then
+            git diff
+            echo "git status is not clean"
+            false
+          fi
+
+      - name: Trying to strip out notebooks
+        shell: bash -l {0}
+        run: |
+          nbdev_clean
+          git status -s # display the status to see which nbs need cleaning up
+          if [[ `git status --porcelain -uno` ]]; then
+            git status -uno
+            echo -e "!!! Detected unstripped out notebooks\n!!!Remember to run nbdev_install_hooks"
+            echo -e "This error can also happen if you are using an older version of nbdev relative to what is in CI.  Please try to upgrade nbdev with the command `pip install -U nbdev`"
+            false
+          fi
+
+      - name: Run nbdev_export
+        shell: bash -l {0}
+        run: |
+          nbdev_export
+          if [[ `git status --porcelain -uno` ]]; then
+            echo "::error::Notebooks and library are not in sync.  Please run nbdev_export."
+            git status -uno
+            git diff
+            exit 1;
+          fi
+
+      - name: Run nbdev_test
+        shell: bash -l {0}
+        run: |
+          nbdev_test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           auto-update-conda: false
           auto-activate-base: false
-          activate-environment: gtbook
+          activate-environment: diffdrr
           python-version: 3.9
           environment-file: environment.yml
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,18 @@
+name: diffdrr
+channels:
+  - conda-forge
+  - pytorch
+  - pytorch3d
+  - nvidia
+dependencies:
+  - pip
+  - pytorch
+  - pytorch3d
+  - pydicom
+  - matplotlib
+  - seaborn
+  - tqdm
+  - imageio
+  - fastcore
+  - pip:
+    - 'pyvista[all]'

--- a/notebooks/api/00_drr.ipynb
+++ b/notebooks/api/00_drr.ipynb
@@ -9,7 +9,6 @@
     "title: DRR\n",
     "description: Module for computing digitally reconstructed radiographs\n",
     "output-file: drr.html\n",
-    "skip_exec: true\n",
     "---"
    ]
   },

--- a/notebooks/api/02_detector.ipynb
+++ b/notebooks/api/02_detector.ipynb
@@ -9,7 +9,6 @@
     "title: Detector (C-Arm)\n",
     "description: Set up the 7 degrees-of-freedom parameters for the C-arm\n",
     "output-file: detector.html\n",
-    "skip_exec: true\n",
     "---"
    ]
   },

--- a/notebooks/api/04_visualization.ipynb
+++ b/notebooks/api/04_visualization.ipynb
@@ -9,7 +9,6 @@
     "title: visualization\n",
     "description: Utility functions to visualize and animate DRRs\n",
     "output-file: visualization.html\n",
-    "skip_exec: true\n",
     "---"
    ]
   },

--- a/notebooks/api/06_utils.ipynb
+++ b/notebooks/api/06_utils.ipynb
@@ -9,7 +9,6 @@
     "title: utils\n",
     "description: Utility functions\n",
     "output-file: utils.html\n",
-    "skip_exec: true\n",
     "---"
    ]
   },

--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -7,7 +7,6 @@
     "---\n",
     "title: DiffDRRg\n",
     "output-file: index.html\n",
-    "skip_exec: true\n",
     "---"
    ]
   },


### PR DESCRIPTION
Replaces the default CI/CD script shipped with `nbdev` for one builds from a conda environment. Essential since PyTorch3D is conda-only, which was creating massive headaches.

Original script: https://github.com/gtbook/gtbook/blob/master/.github/workflows/test_and_deploy.yaml 

Only modification was to use [`micromamba`](https://github.com/mamba-org/setup-micromamba/blob/main/action.yml) instead of `miniconda` for environment setup, since it's wayyyy faster