### PR TITLE
Reorient fiducials using affine matrix

### DIFF
--- a/diffdrr/data.py
+++ b/diffdrr/data.py
@@ -15,7 +15,7 @@ from torchio.transforms.preprocessing import ToCanonical
 # %% auto 0
 __all__ = ['load_example_ct', 'read']
 
-# %% ../notebooks/api/03_data.ipynb 4
+# %% ../notebooks/api/03_data.ipynb 5
 def load_example_ct(
     labels=None,
     orientation="AP",
@@ -37,7 +37,7 @@ def load_example_ct(
         **kwargs,
     )
 
-# %% ../notebooks/api/03_data.ipynb 5
+# %% ../notebooks/api/03_data.ipynb 6
 def read(
     volume: str | Path | ScalarImage,  # CT volume
     labelmap: str | Path | LabelMap = None,  # Labelmap for the CT volume
@@ -132,7 +132,7 @@ def read(
 
     return subject
 
-# %% ../notebooks/api/03_data.ipynb 6
+# %% ../notebooks/api/03_data.ipynb 7
 from diffdrr.pose import RigidTransform
 
 
@@ -163,7 +163,7 @@ def canonicalize(subject):
         subject.fiducials = affine(subject.fiducials)
     return subject
 
-# %% ../notebooks/api/03_data.ipynb 7
+# %% ../notebooks/api/03_data.ipynb 8
 def transform_hu_to_density(volume, bone_attenuation_multiplier):
     volume = volume.to(torch.float32)
 

--- a/diffdrr/data.py
+++ b/diffdrr/data.py
@@ -17,7 +17,10 @@ __all__ = ['load_example_ct', 'read']
 
 # %% ../notebooks/api/03_data.ipynb 4
 def load_example_ct(
-    labels=None, orientation="AP", bone_attenuation_multiplier=1.0
+    labels=None,
+    orientation="AP",
+    bone_attenuation_multiplier=1.0,
+    **kwargs,
 ) -> Subject:
     """Load an example chest CT for demonstration purposes."""
     datadir = Path(__file__).resolve().parent / "data"
@@ -31,6 +34,7 @@ def load_example_ct(
         orientation=orientation,
         bone_attenuation_multiplier=bone_attenuation_multiplier,
         structures=structures,
+        **kwargs,
     )
 
 # %% ../notebooks/api/03_data.ipynb 5
@@ -40,6 +44,7 @@ def read(
     labels: int | list = None,  # Labels from the mask of structures to render
     orientation: str = "AP",  # Frame-of-reference change
     bone_attenuation_multiplier: float = 1.0,  # Scalar multiplier on density of high attenuation voxels
+    fiducials: torch.Tensor = None,  # 3D fiducials in world coordinates
     **kwargs,  # Any additional information to be stored in the torchio.Subject
 ) -> Subject:
     """
@@ -108,6 +113,7 @@ def read(
         mask=mask,
         reorient=reorient,
         density=density,
+        fiducials=fiducials,
         **kwargs,
     )
 
@@ -127,8 +133,12 @@ def read(
     return subject
 
 # %% ../notebooks/api/03_data.ipynb 6
+from diffdrr.pose import RigidTransform
+
+
 def canonicalize(subject):
     # Convert to RAS+ coordinate system
+    affine_original = torch.from_numpy(subject.volume.affine)
     subject = ToCanonical()(subject)
 
     # Move the Subject's isocenter to the origin in world coordinates
@@ -144,6 +154,13 @@ def canonicalize(subject):
         )
         image.affine = Tinv.dot(image.affine)
 
+    # If fiducials are provided (in world coordinates), reorient them
+    if subject.fiducials is not None:
+        affine_new = torch.tensor(image.affine)
+        affine = affine_new @ affine_original.inverse()
+        affine = affine.to(torch.float32)
+        affine = RigidTransform(affine)
+        subject.fiducials = affine(subject.fiducials)
     return subject
 
 # %% ../notebooks/api/03_data.ipynb 7

--- a/notebooks/api/03_data.ipynb
+++ b/notebooks/api/03_data.ipynb
@@ -54,6 +54,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d813be4b-c664-4ca4-84f8-8d4eb6f154e5",
+   "metadata": {},
+   "source": [
+    "CT scans in `DiffDRR` are stored using the `torchio.Subject` dataclass.\n",
+    "`torchio` provides a convenient and consistent mechanism for reading volumes\n",
+    "from a variety of formats and orientations. We canonicalize all volumes to \n",
+    "the RAS+ coordinate space. In addition to reading an input volume, you can also pass\n",
+    "the following to `diffdrr.data.read` when loading a subject:\n",
+    "- `labelmap` : a 3D segmentation of the input volume\n",
+    "- `labels` : a subset of structures from the labelmap that you want to render\n",
+    "- `orientation` : a frame-of-reference change for the C-arm (currently, \"AP\" and \"PA\" are supported)\n",
+    "- `bone_attenuation_multiplier` : a constant multiplier to the estimated density of bone voxels\n",
+    "- `fiducials` : a tensor of 3D fiducial marks *in world coordinates*\n",
+    "- `**kwargs` : any additional kwargs can be passed to the `torchio.Subject` and accessed as a dictionary"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "126d05d3",

--- a/notebooks/api/03_data.ipynb
+++ b/notebooks/api/03_data.ipynb
@@ -62,7 +62,10 @@
    "source": [
     "#| export\n",
     "def load_example_ct(\n",
-    "    labels=None, orientation=\"AP\", bone_attenuation_multiplier=1.0\n",
+    "    labels=None,\n",
+    "    orientation=\"AP\",\n",
+    "    bone_attenuation_multiplier=1.0,\n",
+    "    **kwargs,\n",
     ") -> Subject:\n",
     "    \"\"\"Load an example chest CT for demonstration purposes.\"\"\"\n",
     "    datadir = Path(__file__).resolve().parent / \"data\"\n",
@@ -76,6 +79,7 @@
     "        orientation=orientation,\n",
     "        bone_attenuation_multiplier=bone_attenuation_multiplier,\n",
     "        structures=structures,\n",
+    "        **kwargs,\n",
     "    )"
    ]
   },
@@ -93,6 +97,7 @@
     "    labels: int | list = None,  # Labels from the mask of structures to render\n",
     "    orientation: str = \"AP\",  # Frame-of-reference change\n",
     "    bone_attenuation_multiplier: float = 1.0,  # Scalar multiplier on density of high attenuation voxels\n",
+    "    fiducials: torch.Tensor = None,  # 3D fiducials in world coordinates\n",
     "    **kwargs,  # Any additional information to be stored in the torchio.Subject\n",
     ") -> Subject:\n",
     "    \"\"\"\n",
@@ -161,6 +166,7 @@
     "        mask=mask,\n",
     "        reorient=reorient,\n",
     "        density=density,\n",
+    "        fiducials=fiducials,\n",
     "        **kwargs,\n",
     "    )\n",
     "\n",
@@ -188,8 +194,11 @@
    "outputs": [],
    "source": [
     "#| exporti\n",
+    "from diffdrr.pose import RigidTransform\n",
+    "\n",
     "def canonicalize(subject):\n",
     "    # Convert to RAS+ coordinate system\n",
+    "    affine_original = torch.from_numpy(subject.volume.affine)\n",
     "    subject = ToCanonical()(subject)\n",
     "\n",
     "    # Move the Subject's isocenter to the origin in world coordinates\n",
@@ -205,6 +214,13 @@
     "        )\n",
     "        image.affine = Tinv.dot(image.affine)\n",
     "\n",
+    "    # If fiducials are provided (in world coordinates), reorient them\n",
+    "    if subject.fiducials is not None:\n",
+    "        affine_new = torch.tensor(image.affine)\n",
+    "        affine = affine_new @ affine_original.inverse()\n",
+    "        affine = affine.to(torch.float32)\n",
+    "        affine = RigidTransform(affine)\n",
+    "        subject.fiducials = affine(subject.fiducials)\n",
     "    return subject"
    ]
   },


### PR DESCRIPTION
Closes #235 

Adds the ability to pass 3D fiducial markers (in world coordinates) to `diffdrr.data.read` and reorient them according to the CT scan's affine matrix.