### PR TITLE
fix walrus operator in assert statement, leading to problems with optimized code

### DIFF
--- a/diffdrr/pose.py
+++ b/diffdrr/pose.py
@@ -106,7 +106,8 @@ class RigidTransform(torch.nn.Module):
 
 # %% ../notebooks/api/06_pose.ipynb 7
 def make_matrix(R, t):
-    assert (batch_size := len(R)) == len(t)
+    batch_size = len(R)
+    assert batch_size == len(t)
     matrix = torch.zeros(batch_size, 4, 4).to(R)
     matrix[..., :3, :3] = R
     matrix[..., :3, 3] = t


### PR DESCRIPTION
Using the optimization flag `-O` with the Python interpreter eliminates assert statements. Thus, asserts should have no side-effects.

This small PR moves the inline assignment operator (walrus) out of an assert-statement to make it free of side-effects, so that it can be run in deployments where the `-O` flag is used.